### PR TITLE
LPD-93478 LPD-93468 LPD-93841 Add the AI Assistant chat to the CMS

### DIFF
--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/AIAssistantChat.tsx
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/AIAssistantChat/AIAssistantChat.tsx
@@ -9,6 +9,7 @@ import ClayForm from '@clayui/form';
 import ClayIcon from '@clayui/icon';
 import ClayLayout from '@clayui/layout';
 import ClayLoadingIndicator from '@clayui/loading-indicator';
+import classNames from 'classnames';
 import {EventSource} from 'eventsource';
 import React, {useCallback, useEffect, useRef, useState} from 'react';
 
@@ -47,17 +48,21 @@ interface ReportContext {
 interface AIAssistantChatProps {
 	embedded?: boolean;
 	getContext: () => ChatContext;
+	hideTriggerLabel?: boolean;
 	initialMessage?: string;
 	instructionDefinitionScope: string;
 	quickActions?: string[];
+	triggerClassName?: string;
 }
 
 const AIAssistantChat: React.FC<AIAssistantChatProps> = ({
 	embedded = false,
 	getContext,
+	hideTriggerLabel = false,
 	initialMessage,
 	instructionDefinitionScope,
 	quickActions,
+	triggerClassName,
 }) => {
 	const [active, setActive] = useState<boolean>(false);
 	const [feedbackGiven, setFeedbackGiven] = useState<Record<number, boolean>>(
@@ -510,19 +515,22 @@ const AIAssistantChat: React.FC<AIAssistantChatProps> = ({
 				<ClayButton
 					aria-label={Liferay.Language.get('ai-assistant')}
 					borderless
-					className="text-primary"
+					className={classNames('text-primary', triggerClassName)}
 					displayType="secondary"
 					ref={triggerRef}
 				>
 					<ClayIcon
-						className="mr-2"
 						height={16}
 						spritemap={Liferay.Icons.spritemap}
 						symbol="stars"
 						width={16}
 					/>
 
-					{Liferay.Language.get('ai-assistant')}
+					{!hideTriggerLabel && (
+						<span className="ml-2">
+							{Liferay.Language.get('ai-assistant')}
+						</span>
+					)}
 				</ClayButton>
 			}
 		>

--- a/modules/apps/site-initializer/site-initializer-cms/src/main/resources/site-initializer/fragments/group/cms/fragments/page-bar/index.html
+++ b/modules/apps/site-initializer/site-initializer-cms/src/main/resources/site-initializer/fragments/group/cms/fragments/page-bar/index.html
@@ -15,6 +15,9 @@
 				</div>
 			</li>
 			<li class="tbar-item">
+				<lfr-drop-zone data-lfr-drop-zone-id="aiAssistant"></lfr-drop-zone>
+			</li>
+			<li class="tbar-item">
 				<lfr-drop-zone data-lfr-drop-zone-id="bulkActionsMonitor"></lfr-drop-zone>
 			</li>
 			<li class="tbar-item">

--- a/modules/apps/site-initializer/site-initializer-cms/src/main/resources/site-initializer/layout-page-templates/master-pages/cms-basic-master/page-definition.json
+++ b/modules/apps/site-initializer/site-initializer-cms/src/main/resources/site-initializer/layout-page-templates/master-pages/cms-basic-master/page-definition.json
@@ -73,6 +73,29 @@
 							}
 						],
 						"type": "FragmentDropZone"
+					},
+					{
+						"definition": {
+							"fragmentDropZoneId": "aiAssistant"
+						},
+						"id": "f44f9465-0c71-4c12-bd4a-df7b0b6e2d13",
+						"pageElements": [
+							{
+								"definition": {
+									"fragment": {
+										"key": "com.liferay.site.cms.site.initializer.internal.fragment.renderer.AIAssistantComponentSectionFragmentRenderer"
+									},
+									"fragmentConfig": {
+									},
+									"fragmentFields": [
+									],
+									"indexed": true
+								},
+								"id": "3bbb1b81-00bb-49d0-a725-2dedbf6c274c",
+								"type": "Fragment"
+							}
+						],
+						"type": "FragmentDropZone"
 					}
 				],
 				"type": "Fragment"

--- a/modules/apps/site-initializer/site-initializer-cms/src/main/resources/site-initializer/layout-page-templates/master-pages/cms-master/page-definition.json
+++ b/modules/apps/site-initializer/site-initializer-cms/src/main/resources/site-initializer/layout-page-templates/master-pages/cms-master/page-definition.json
@@ -118,6 +118,29 @@
 											}
 										],
 										"type": "FragmentDropZone"
+									},
+									{
+										"definition": {
+											"fragmentDropZoneId": "aiAssistant"
+										},
+										"id": "1df5fa1b-ebb8-45d4-99f8-9ed204ccf341",
+										"pageElements": [
+											{
+												"definition": {
+													"fragment": {
+														"key": "com.liferay.site.cms.site.initializer.internal.fragment.renderer.AIAssistantComponentSectionFragmentRenderer"
+													},
+													"fragmentConfig": {
+													},
+													"fragmentFields": [
+													],
+													"indexed": true
+												},
+												"id": "00a73886-650d-429d-af1a-6dc596a83151",
+												"type": "Fragment"
+											}
+										],
+										"type": "FragmentDropZone"
 									}
 								],
 								"type": "Fragment"

--- a/modules/apps/site-initializer/site-initializer-cms/src/main/resources/site-initializer/layout-page-templates/master-pages/cms-space-master/page-definition.json
+++ b/modules/apps/site-initializer/site-initializer-cms/src/main/resources/site-initializer/layout-page-templates/master-pages/cms-space-master/page-definition.json
@@ -118,6 +118,29 @@
 											}
 										],
 										"type": "FragmentDropZone"
+									},
+									{
+										"definition": {
+											"fragmentDropZoneId": "aiAssistant"
+										},
+										"id": "34ac970b-5faf-4f89-b807-4781a5755d12",
+										"pageElements": [
+											{
+												"definition": {
+													"fragment": {
+														"key": "com.liferay.site.cms.site.initializer.internal.fragment.renderer.AIAssistantComponentSectionFragmentRenderer"
+													},
+													"fragmentConfig": {
+													},
+													"fragmentFields": [
+													],
+													"indexed": true
+												},
+												"id": "9d86d4c5-5371-40e6-9527-2add939ee98a",
+												"type": "Fragment"
+											}
+										],
+										"type": "FragmentDropZone"
 									}
 								],
 								"type": "Fragment"

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/fragment/renderer/AIAssistantComponentSectionFragmentRenderer.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/fragment/renderer/AIAssistantComponentSectionFragmentRenderer.java
@@ -1,0 +1,48 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.site.cms.site.initializer.internal.fragment.renderer;
+
+import com.liferay.fragment.renderer.FragmentRenderer;
+import com.liferay.fragment.renderer.FragmentRendererContext;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+import java.util.Collections;
+import java.util.Map;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Mylena Monte
+ */
+@Component(service = FragmentRenderer.class)
+public class AIAssistantComponentSectionFragmentRenderer
+	extends BaseComponentSectionFragmentRenderer {
+
+	@Override
+	public String getCollectionKey() {
+		return "sections";
+	}
+
+	@Override
+	protected String getLabelKey() {
+		return "ai-assistant";
+	}
+
+	@Override
+	protected String getModuleName() {
+		return "CMSAIAssistant";
+	}
+
+	@Override
+	protected Map<String, Object> getProps(
+		FragmentRendererContext fragmentRendererContext,
+		HttpServletRequest httpServletRequest) {
+
+		return Collections.emptyMap();
+	}
+
+}

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/css/components/CMSAIAssistant.scss
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/css/components/CMSAIAssistant.scss
@@ -1,0 +1,15 @@
+.cms-ai-assistant__trigger.btn {
+	align-items: center;
+	border-radius: 50%;
+	display: inline-flex;
+	height: 2.5rem;
+	justify-content: center;
+	padding: 0;
+	width: 2.5rem;
+
+	&:hover,
+	&[aria-expanded='true'] {
+		background: linear-gradient(135.99deg, #aa33ff 4.37%, #0b5fff 98.53%);
+		color: #fff;
+	}
+}

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/common/components/CMSAIAssistant.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/common/components/CMSAIAssistant.tsx
@@ -1,0 +1,20 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import '../../../css/components/CMSAIAssistant.scss';
+
+import {AIAssistantChat} from '@liferay/ai-hub-cell-js-components-web';
+import React from 'react';
+
+export default function CMSAIAssistant() {
+	return (
+		<AIAssistantChat
+			getContext={() => ({})}
+			hideTriggerLabel
+			instructionDefinitionScope="cms"
+			triggerClassName="cms-ai-assistant__trigger"
+		/>
+	);
+}

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/content_editor/components/ContentEditorToolbar.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/content_editor/components/ContentEditorToolbar.tsx
@@ -10,7 +10,6 @@ import {ClayDropDownWithItems} from '@clayui/drop-down';
 import {ClayInput} from '@clayui/form';
 import ClayIcon from '@clayui/icon';
 import ClayLink from '@clayui/link';
-import {AIAssistantChat} from '@liferay/ai-hub-cell-js-components-web';
 import {isCtrlOrMeta} from '@liferay/layout-js-components-web';
 import classNames from 'classnames';
 import {openToast, useSessionState} from 'frontend-js-components-web';
@@ -18,6 +17,7 @@ import {sessionStorage, sub} from 'frontend-js-web';
 import React, {useCallback, useEffect, useId, useRef, useState} from 'react';
 import {flushSync} from 'react-dom';
 
+import CMSAIAssistant from '../../common/components/CMSAIAssistant';
 import Toolbar from '../../common/components/Toolbar';
 import {toMomentDate} from './ScheduleField';
 import SchedulePublicationModal from './SchedulePublicationModal';
@@ -215,10 +215,7 @@ export default function ContentEditorToolbar({
 			{Liferay.FeatureFlags['LPD-62272'] && (
 				<>
 					<Toolbar.Item>
-						<AIAssistantChat
-							getContext={() => ({})}
-							instructionDefinitionScope="cms"
-						/>
+						<CMSAIAssistant />
 					</Toolbar.Item>
 
 					<div

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/index.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/index.ts
@@ -4,6 +4,7 @@
  */
 
 export {default as Breadcrumb} from './common/components/Breadcrumb';
+export {default as CMSAIAssistant} from './common/components/CMSAIAssistant';
 export {default as EnterpriseProductMenuBanner} from './common/components/EnterpriseProductMenuBanner';
 export {default as SpaceSelector} from './common/components/SpaceSelector';
 export {default as SpaceSticker} from './common/components/SpaceSticker';
@@ -20,6 +21,7 @@ export {
 } from './common/types/BulkActionTask';
 export {ObjectField, StateFlowValue} from './common/types/ObjectDefinition';
 export {type Space} from './common/types/Space';
+
 export {
 	displayCreateSuccessToast,
 	displayCreateTaskErrorToast,
@@ -31,15 +33,15 @@ export {
 	displaySystemErrorToast,
 	displayNameInUseErrorToast,
 } from './common/utils/toastUtil';
-
 export {default as ContentEditorPreview} from './content_editor/components/ContentEditorPreview';
+
 export {default as ContentEditorSidePanel} from './content_editor/components/ContentEditorSidePanel';
 
 // Content Editor
 
 export {default as ContentEditorToolbar} from './content_editor/components/ContentEditorToolbar';
-export {default as Spaces} from './content_editor/components/Spaces';
 
+export {default as Spaces} from './content_editor/components/Spaces';
 export {default as CommentsPanel} from './content_editor/components/panels/CommentsPanel';
 export {default as BulkActionTaskAssets} from './main_view/bulk_action_task/BulkActionTaskAssets';
 export {default as BulkActionTaskDuration} from './main_view/bulk_action_task/BulkActionTaskDuration';


### PR DESCRIPTION
The embedded AI agents for the CMS all run inside a single AI Assistant chat, so that chat has to be reachable from the CMS itself. This surfaces the existing AIAssistantChat as a button in the CMS top navigation bar, to the left of the applications menu, by adding a fragment renderer that the page-bar fragment mounts through a new drop zone wired into the master pages, and reuses the same button in the content editor toolbar.

The shared AIAssistantChat gains optional hideTriggerLabel and triggerClassName props so the CMS can render it as an icon-only circular trigger that shows a gradient on hover and while the chat is open, without changing how other consumers render it.