### PR TITLE
LPD-94145 Mount the CMS Select File AI Assistant from the fragment

### DIFF
--- a/modules/apps/ai-hub-cell/ai-hub-cell-impl/build.gradle
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-impl/build.gradle
@@ -1,10 +1,13 @@
 dependencies {
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
+	compileOnly group: "jakarta.servlet", name: "jakarta.servlet-api", version: "6.0.0"
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.4.0"
 	compileOnly project(":apps:ai-hub-cell:ai-hub-cell-api")
 	compileOnly project(":apps:configuration-admin:configuration-admin-api")
+	compileOnly project(":apps:frontend-js:frontend-js-importmaps-extender-api")
 	compileOnly project(":apps:oauth2-provider:oauth2-provider-api")
 	compileOnly project(":apps:portal-security:portal-security-service-access-policy-api")
+	compileOnly project(":apps:portal-url-builder:portal-url-builder-api")
 	compileOnly project(":apps:static:portal-configuration:portal-configuration-persistence-api")
 	compileOnly project(":core:petra:petra-string")
 }

--- a/modules/apps/ai-hub-cell/ai-hub-cell-impl/src/main/java/com/liferay/ai/hub/cell/internal/js/importmaps/extender/AIHubCellJSComponentsWebDynamicJSImportMapsContributor.java
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-impl/src/main/java/com/liferay/ai/hub/cell/internal/js/importmaps/extender/AIHubCellJSComponentsWebDynamicJSImportMapsContributor.java
@@ -1,0 +1,57 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.ai.hub.cell.internal.js.importmaps.extender;
+
+import com.liferay.frontend.js.importmaps.extender.DynamicJSImportMapsContributor;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.url.builder.AbsolutePortalURLBuilder;
+import com.liferay.portal.url.builder.AbsolutePortalURLBuilderFactory;
+import com.liferay.portal.url.builder.ESModuleAbsolutePortalURLBuilder;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+import java.io.IOException;
+import java.io.Writer;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Víctor Galán
+ */
+@Component(service = DynamicJSImportMapsContributor.class)
+public class AIHubCellJSComponentsWebDynamicJSImportMapsContributor
+	implements DynamicJSImportMapsContributor {
+
+	@Override
+	public void writeGlobalImports(
+			HttpServletRequest httpServletRequest, Writer writer)
+		throws IOException {
+
+		writer.write("\"@liferay/ai-hub-cell-js-components-web\": \"");
+
+		AbsolutePortalURLBuilder absolutePortalURLBuilder =
+			_absolutePortalURLBuilderFactory.getAbsolutePortalURLBuilder(
+				httpServletRequest);
+
+		ESModuleAbsolutePortalURLBuilder esModuleAbsolutePortalURLBuilder =
+			absolutePortalURLBuilder.forESModule(
+				"ai-hub-cell-js-components-web", "index.js");
+
+		writer.write(esModuleAbsolutePortalURLBuilder.build());
+
+		writer.write(StringPool.QUOTE);
+	}
+
+	@Override
+	public void writeScopedImports(
+		HttpServletRequest httpServletRequest, Writer writer) {
+	}
+
+	@Reference
+	private AbsolutePortalURLBuilderFactory _absolutePortalURLBuilderFactory;
+
+}

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/package.json
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/package.json
@@ -18,6 +18,7 @@
 		"@clayui/provider": "^3.165.0",
 		"@clayui/toolbar": "^3.165.0",
 		"@clayui/tooltip": "^3.165.0",
+		"@liferay/frontend-js-react-web": "*",
 		"ckeditor5": "46.0.3",
 		"classnames": "2.3.1",
 		"eventsource": "^4.0.0",

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/index.ts
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/index.ts
@@ -28,3 +28,4 @@ export type {
 	ReportFeedbackSurface,
 } from './ReportFeedback/api';
 export {default as WritingAssistant} from './WritingAssistant/WritingAssistant';
+export {default as renderAIAssistantChat} from './renderAIAssistantChat';

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/renderAIAssistantChat.ts
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/renderAIAssistantChat.ts
@@ -1,0 +1,20 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {render} from '@liferay/frontend-js-react-web';
+
+import AIAssistantChat from './AIAssistantChat/AIAssistantChat';
+
+import type {ComponentProps} from 'react';
+
+export default function renderAIAssistantChat(
+	container: Element,
+	props: ComponentProps<typeof AIAssistantChat>
+): void {
+
+	// @ts-ignore
+
+	render(AIAssistantChat, props, container);
+}

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/tsconfig.json
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"@generated": "0ea2f2d32ca5e3f6ecf91645c4ca8b6706f6b1a9",
+	"@generated": "cbb1daa9016dfa3314c9adb1f287a0de753968b5",
 	"@readonly": "** AUTO-GENERATED: DO NOT EDIT **",
 	"compilerOptions": {
 		"allowSyntheticDefaultImports": true,
@@ -11,6 +11,9 @@
 		"module": "es2022",
 		"moduleResolution": "node",
 		"paths": {
+			"@liferay/frontend-js-react-web": [
+				"../../../../../../../frontend-js/frontend-js-react-web/src/main/resources/META-INF/resources/js/index.ts"
+			],
 			"frontend-js-components-web": [
 				"../../../../../../../frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/index.ts"
 			],
@@ -37,6 +40,9 @@
 		"../../../../../../../../global.d.ts"
 	],
 	"references": [
+		{
+			"path": "../../../../../../../frontend-js/frontend-js-react-web/src/main/resources/META-INF/resources/tsconfig.json"
+		},
 		{
 			"path": "../../../../../../../frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/tsconfig.json"
 		},

--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/test/tsconfig.json
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/test/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"@generated": "3d7556e4c1aadc42591e52c6f717a1fe45fdd8ec",
+	"@generated": "71ded35b5c69053ed6393386c89600df93f1e8b7",
 	"@readonly": "** AUTO-GENERATED: DO NOT EDIT **",
 	"compilerOptions": {
 		"allowSyntheticDefaultImports": true,
@@ -11,6 +11,9 @@
 		"module": "es2022",
 		"moduleResolution": "node",
 		"paths": {
+			"@liferay/frontend-js-react-web": [
+				"../../../frontend-js/frontend-js-react-web/src/main/resources/META-INF/resources/js/index.ts"
+			],
 			"frontend-js-components-web": [
 				"../../../frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/index.ts"
 			],
@@ -39,6 +42,9 @@
 		"../src/**/*.tsx"
 	],
 	"references": [
+		{
+			"path": "../../../frontend-js/frontend-js-react-web/src/main/resources/META-INF/resources/tsconfig.json"
+		},
 		{
 			"path": "../../../frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/tsconfig.json"
 		},

--- a/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/file-upload/index.html
+++ b/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/file-upload/index.html
@@ -30,9 +30,9 @@
 					<input accept="${(input.attributes.allowedFileExtensions?has_content)?then(input.attributes.allowedFileExtensions, '*')}" aria-describedby="${fragmentElementId}-file-upload-help-text" aria-labelledby="${fragmentElementId}-file-upload-label ${fragmentElementId}-file-upload-button-label [#if  input.errorMessage?has_content]${fragmentElementId}-file-upload-error-message[/#if]" class="file-upload-input sr-only" formenctype="multipart/form-data" id="${fragmentElementId}-file-upload" [#if !localFileUploaded]name="${input.name}"[/#if] ${input.required?then('required', '' )} type="${showDocumentLibrarySelector?then('text', 'file')}" [#if input.value??]value="${input.value}"[/#if] tabIndex="-1" />
 				</div>
 
-				<div class="ml-2">
-					<lfr-drop-zone data-lfr-drop-zone-id="aiAssistant"></lfr-drop-zone>
-				</div>
+				[#if input.attributes.isCMS?? && input.attributes.isCMS]
+					<div class="file-upload-ai-assistant ml-2"></div>
+				[/#if]
 
 				<strong aria-label="${htmlUtil.escape(input.label)}" class="forms-file-upload-file-name pl-2" data-placeholder="${languageUtil.get(locale, "no-file-selected")}" role="textbox" value="">
 					[#if input.attributes.fileName??]${htmlUtil.escape(input.attributes.fileName)}[/#if]

--- a/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/file-upload/index.js
+++ b/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/file-upload/index.js
@@ -24,6 +24,20 @@ const selectButton = document.getElementById(
 	`${fragmentElementId}-file-upload-button-label`
 );
 
+const aiAssistantContainer = wrapper.querySelector('.file-upload-ai-assistant');
+
+if (aiAssistantContainer && Liferay.FeatureFlags['LPD-62272']) {
+	import('@liferay/ai-hub-cell-js-components-web').then(
+		({renderAIAssistantChat}) => {
+			renderAIAssistantChat(aiAssistantContainer, {
+				hideTriggerLabel: true,
+				instructionDefinitionScope: 'cms',
+				triggerRound: true,
+			});
+		}
+	);
+}
+
 function showRemoveButton() {
 	removeButton.classList.remove('d-none');
 	removeButton.addEventListener('click', onRemoveFile);

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/util/ActionUtil.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/util/ActionUtil.java
@@ -23,7 +23,6 @@ import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItemBuilder;
 import com.liferay.info.field.InfoField;
 import com.liferay.info.field.InfoFieldSet;
 import com.liferay.info.field.InfoFieldSetEntry;
-import com.liferay.info.field.type.FileInfoFieldType;
 import com.liferay.info.field.type.RelationshipInfoFieldType;
 import com.liferay.info.form.InfoForm;
 import com.liferay.info.item.InfoItemServiceRegistry;
@@ -41,7 +40,6 @@ import com.liferay.layout.util.structure.ColumnLayoutStructureItem;
 import com.liferay.layout.util.structure.ContainerStyledLayoutStructureItem;
 import com.liferay.layout.util.structure.FormRelationshipStyledLayoutStructureItem;
 import com.liferay.layout.util.structure.FormStyledLayoutStructureItem;
-import com.liferay.layout.util.structure.FragmentDropZoneLayoutStructureItem;
 import com.liferay.layout.util.structure.FragmentStyledLayoutStructureItem;
 import com.liferay.layout.util.structure.LayoutStructure;
 import com.liferay.layout.util.structure.LayoutStructureItem;
@@ -92,7 +90,6 @@ import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.kernel.uuid.PortalUUIDUtil;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.segments.service.SegmentsExperienceLocalServiceUtil;
-import com.liferay.site.cms.site.initializer.internal.fragment.renderer.AIAssistantIconComponentSectionFragmentRenderer;
 import com.liferay.site.cms.site.initializer.internal.fragment.renderer.SpacesComponentSectionFragmentRenderer;
 
 import jakarta.servlet.http.HttpServletRequest;
@@ -1099,45 +1096,6 @@ public class ActionUtil {
 		return getBaseViewFolderURL(themeDisplay) + objectEntryFolderId;
 	}
 
-	private static void _addAIAssistantFragmentDropZone(
-			List<FragmentEntryLink> addedFragmentEntryLinks,
-			FragmentEntryLinkService fragmentEntryLinkService,
-			FragmentRendererRegistry fragmentRendererRegistry,
-			FragmentStyledLayoutStructureItem fragmentStyledLayoutStructureItem,
-			Layout layout, LayoutStructure layoutStructure,
-			long segmentsExperienceId, ServiceContext serviceContext)
-		throws Exception {
-
-		if (fragmentStyledLayoutStructureItem == null) {
-			return;
-		}
-
-		FragmentEntryLink fragmentEntryLink = _addFragmentEntryLink(
-			StringPool.BLANK, fragmentEntryLinkService,
-			fragmentRendererRegistry,
-			AIAssistantIconComponentSectionFragmentRenderer.class.getName(),
-			layout, segmentsExperienceId, serviceContext);
-
-		if (fragmentEntryLink == null) {
-			return;
-		}
-
-		FragmentDropZoneLayoutStructureItem
-			fragmentDropZoneLayoutStructureItem =
-				(FragmentDropZoneLayoutStructureItem)
-					layoutStructure.addFragmentDropZoneLayoutStructureItem(
-						fragmentStyledLayoutStructureItem.getItemId(), -1);
-
-		fragmentDropZoneLayoutStructureItem.setFragmentDropZoneId(
-			"aiAssistant");
-
-		layoutStructure.addFragmentStyledLayoutStructureItem(
-			fragmentEntryLink.getFragmentEntryLinkId(),
-			fragmentDropZoneLayoutStructureItem.getItemId(), 0);
-
-		addedFragmentEntryLinks.add(fragmentEntryLink);
-	}
-
 	private static LayoutPageTemplateEntry
 			_addEditContentDefaultLayoutPageTemplateEntry(
 				long classNameId, FormManager formManager,
@@ -1256,7 +1214,7 @@ public class ActionUtil {
 			0, contributedRendererKey, fragmentEntry.getType(), serviceContext);
 	}
 
-	private static FragmentStyledLayoutStructureItem _addInputFragmentEntryLink(
+	private static void _addInputFragmentEntryLink(
 			List<FragmentEntryLink> addedFragmentEntryLinks,
 			JSONObject configurationJSONObject, FormManager formManager,
 			String fragmentEntryKey, InfoField<?> infoField, Layout layout,
@@ -1267,7 +1225,7 @@ public class ActionUtil {
 		throws Exception {
 
 		if (infoField == null) {
-			return null;
+			return;
 		}
 
 		FragmentStyledLayoutStructureItem fragmentStyledLayoutStructureItem =
@@ -1277,7 +1235,7 @@ public class ActionUtil {
 				serviceContext);
 
 		if (fragmentStyledLayoutStructureItem == null) {
-			return null;
+			return;
 		}
 
 		fragmentStyledLayoutStructureItem.updateItemConfig(
@@ -1308,8 +1266,6 @@ public class ActionUtil {
 		if (fragmentEntryLink != null) {
 			addedFragmentEntryLinks.add(fragmentEntryLink);
 		}
-
-		return fragmentStyledLayoutStructureItem;
 	}
 
 	private static LayoutStructure _addInputFragmentEntryLinks(
@@ -1463,24 +1419,11 @@ public class ActionUtil {
 					}
 				}
 
-				FragmentStyledLayoutStructureItem
-					fragmentStyledLayoutStructureItem =
-						_addInputFragmentEntryLink(
-							addedFragmentEntryLinks, null, formManager, null,
-							infoField, layout, layoutStructure,
-							layoutStructureItem, readOnly, segmentsExperienceId,
-							serviceContext, stylesJSONObject);
-
-				if (!readOnly &&
-					(FileInfoFieldType.INSTANCE ==
-						infoField.getInfoFieldType())) {
-
-					_addAIAssistantFragmentDropZone(
-						addedFragmentEntryLinks, fragmentEntryLinkService,
-						fragmentRendererRegistry,
-						fragmentStyledLayoutStructureItem, layout,
-						layoutStructure, segmentsExperienceId, serviceContext);
-				}
+				_addInputFragmentEntryLink(
+					addedFragmentEntryLinks, null, formManager, null,
+					(InfoField<?>)infoFieldSetEntry, layout, layoutStructure,
+					layoutStructureItem, readOnly, segmentsExperienceId,
+					serviceContext, stylesJSONObject);
 			}
 			else if (infoFieldSetEntry instanceof InfoFieldSet) {
 				layoutStructure = _addInputFragmentEntryLinks(


### PR DESCRIPTION
WIP proposal reworking how the AI Assistant is placed next to the CMS Select File button.

Instead of injecting the AI Assistant fragment into a dropzone from Java (`ActionUtil`) when generating the CMS edit-content layout, this mounts the React component client-side from the `file-upload` input fragment. It removes the coupling between the generic layout builder and a specific field type, and drops the shared `aiAssistant` dropzone from the input fragment.

## Commits

- **Expose a renderer to mount the AI Assistant from a fragment** (`ai-hub-cell`): adds `renderAIAssistantChat` and publishes the module in the import map through a `DynamicJSImportMapsContributor`, so a fragment (which runs in a native ES module context and cannot resolve `@liferay/frontend-js-react-web`) can import it by name.
- **Render the AI Assistant next to the CMS Select File button**: the `file-upload` input fragment renders a container only in a CMS context and mounts the assistant when the `LPD-62272` feature flag is enabled.
- **Remove the Java dropzone injection**: `ActionUtil` no longer injects the assistant fragment into a dropzone.

## Notes

- Scoped to CMS via the fragment's `isCMS` attribute plus the feature flag.
- The page-bar AI Assistant is intentionally left untouched: it keeps its declarative dropzone filled by the master-page page-definition, which is the idiomatic pattern there.
- Deployed locally; verified server-side that the import map serves `@liferay/ai-hub-cell-js-components-web` and that the module resolves. Not yet visually confirmed in the browser.
